### PR TITLE
FIX(Cargo.toml): add feature router to support wasm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,10 @@ readme = "README.md"
 categories = ["cryptography", "algorithms"]
 keywords = ["bcrypt", "hash", "salt", "bmcf", "mcf"]
 
+[features]
+#Enable this feature to support wasm32-unknown-unknown target
+js = ["getrandom/js"]
+
 [dependencies]
 base64 = "0.13"
 getrandom = "0.2"


### PR DESCRIPTION
Add feature `js` to support wasm target.

- Fix: Cargo.toml
  - features.js = ["getrandom/js"]
  - https://docs.rs/getrandom/0.2.7/getrandom/\#webassembly-support